### PR TITLE
Refactor Zumji contracts

### DIFF
--- a/SMART-CONTRACTS/Owned.sol
+++ b/SMART-CONTRACTS/Owned.sol
@@ -1,0 +1,28 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+/**
+ * @title Owned
+ * @dev Basic access control mechanism with an owner.
+ */
+contract Owned {
+    address public owner;
+
+    event OwnershipTransferred(address indexed previousOwner, address indexed newOwner);
+
+    constructor() {
+        owner = msg.sender;
+        emit OwnershipTransferred(address(0), msg.sender);
+    }
+
+    modifier onlyOwner() {
+        require(msg.sender == owner, "Not owner");
+        _;
+    }
+
+    function transferOwnership(address newOwner) external onlyOwner {
+        require(newOwner != address(0), "Zero address");
+        emit OwnershipTransferred(owner, newOwner);
+        owner = newOwner;
+    }
+}

--- a/SMART-CONTRACTS/SafeERC20.sol
+++ b/SMART-CONTRACTS/SafeERC20.sol
@@ -1,0 +1,18 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.20;
+
+import "./IERC20.sol";
+
+/**
+ * @title SafeERC20
+ * @dev Simplified safe ERC20 operations.
+ */
+library SafeERC20 {
+    function safeTransfer(IERC20 token, address to, uint256 amount) internal {
+        require(token.transfer(to, amount), "SafeERC20: transfer failed");
+    }
+
+    function safeTransferFrom(IERC20 token, address from, address to, uint256 amount) internal {
+        require(token.transferFrom(from, to, amount), "SafeERC20: transferFrom failed");
+    }
+}


### PR DESCRIPTION
## Summary
- create simple `Owned` access control contract
- add `SafeERC20` library for robust token transfers
- refactor `Zumji.sol` to use new helpers and adjustable parameters

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_685778124f8c8328b0bcdda428516a0a