### PR TITLE
Add statistics page

### DIFF
--- a/src/constants/urls/urls.ts
+++ b/src/constants/urls/urls.ts
@@ -3,3 +3,4 @@ export const finance = '/finance';
 export const p2e = '/p2e';
 export const profile = '/profile';
 export const adminDashboard = '/dashboard';
+export const stats = '/stats';

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -10,7 +10,8 @@ import { getAccount } from "@wagmi/core";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { CustomConnectButton } from "@/components/CustomConnectButton";
-import { home, finance, p2e, profile } from "@/constants/urls/urls";
+import { home, finance, p2e, profile, stats } from "@/constants/urls/urls";
+import { FaChartBar } from "react-icons/fa6";
 import Image from "next/image";
 import { zumjiLogo } from "@/constants/images";
 import ZumjiLogo from "@/components/logo/Logo";
@@ -29,6 +30,7 @@ const Layout = ({ subNavBarTitle, children }: { subNavBarTitle?: string, childre
     { label: "Home", icon: IoIosHome, href: home },
     { label: "Finance", icon: SiCoinmarketcap, href: finance },
     { label: "P2E", icon: RiBillLine, href: p2e },
+    { label: "Stats", icon: FaChartBar, href: stats },
     { label: "Profile", icon: RxAvatar, href: profile },
   ];
 
@@ -79,7 +81,7 @@ const Layout = ({ subNavBarTitle, children }: { subNavBarTitle?: string, childre
 
         {/* Footer Navigation */}
         <div className="fixed bottom-0 left-0 z-50 w-full h-16 bg-black border-t border-gray-200 md:static md:h-auto">
-          <div className="grid h-full max-w-lg grid-cols-4 mx-auto font-medium md:max-w-none md:flex md:justify-center">
+          <div className="grid h-full max-w-lg grid-cols-5 mx-auto font-medium md:max-w-none md:flex md:justify-center">
             {isOnboarded && isConnected && navItems.map((item) => (
               <NavItem key={item.label} {...item} />
             ))}

--- a/src/pages/stats/index.tsx
+++ b/src/pages/stats/index.tsx
@@ -1,0 +1,82 @@
+import React, { useEffect, useState } from 'react';
+import { Block, Preloader } from 'konsta/react';
+import Layout from '../Layout';
+import { ethers } from 'ethers';
+import { ZUMJI_ABI, ZUMJI_CONTRACT } from '@/utils/contracts';
+import { FaUsers, FaBullhorn, FaHandHoldingUsd } from 'react-icons/fa';
+import { GiBriefcase } from 'react-icons/gi';
+
+interface StatCardProps {
+  title: string;
+  value: string | number;
+  icon: React.ReactNode;
+}
+
+const StatCard = ({ title, value, icon }: StatCardProps) => (
+  <div className="p-6 text-center rounded-xl bg-white/5 backdrop-blur-lg border border-white/10 shadow-lg">
+    <div className="flex items-center justify-center text-yellow-500 text-3xl mb-2">
+      {icon}
+    </div>
+    <h3 className="text-xl font-semibold text-white mb-1">{value}</h3>
+    <p className="text-sm text-gray-300">{title}</p>
+  </div>
+);
+
+const StatsPage: React.FC = () => {
+  const [loading, setLoading] = useState(false);
+  const [traders, setTraders] = useState(0);
+  const [totalStaked, setTotalStaked] = useState('0');
+  const [totalBorrowed, setTotalBorrowed] = useState('0');
+  const [adverts, setAdverts] = useState(0);
+
+  useEffect(() => {
+    const provider = new ethers.providers.JsonRpcProvider('https://forno.celo.org');
+    const contract = new ethers.Contract(ZUMJI_CONTRACT, ZUMJI_ABI, provider);
+
+    const fetchStats = async () => {
+      setLoading(true);
+      try {
+        const [staked, borrowed, advertCount] = await Promise.all([
+          contract.totalStaked(),
+          contract.totalBorrowed(),
+          contract.getAdvertCount(),
+        ]);
+
+        const onboarded = await contract.queryFilter(contract.filters.Onboarded());
+        const uniqueUsers = Array.from(new Set(onboarded.map((ev: any) => ev.args?.trader.toLowerCase())));
+
+        setTraders(uniqueUsers.length);
+        setTotalStaked(ethers.utils.formatEther(staked));
+        setTotalBorrowed(ethers.utils.formatEther(borrowed));
+        setAdverts(advertCount.toNumber());
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchStats();
+  }, []);
+
+  return (
+    <Layout subNavBarTitle="Zumji >> Stats">
+      <div className="m-5 h-full">
+        <Block>
+          {loading ? (
+            <Preloader className="mx-auto" />
+          ) : (
+            <div className="grid gap-6 sm:grid-cols-2 md:grid-cols-4">
+              <StatCard title="Traders" value={traders} icon={<FaUsers />} />
+              <StatCard title="Total Staked" value={Number(totalStaked).toFixed(2)} icon={<GiBriefcase />} />
+              <StatCard title="Total Borrowed" value={Number(totalBorrowed).toFixed(2)} icon={<FaHandHoldingUsd />} />
+              <StatCard title="Adverts" value={adverts} icon={<FaBullhorn />} />
+            </div>
+          )}
+        </Block>
+      </div>
+    </Layout>
+  );
+};
+
+export default StatsPage;


### PR DESCRIPTION
## Summary
- add new `stats` URL constant
- add navigation link for Stats and adjust grid layout
- implement statistics page with live metrics from smart contract

## Testing
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6862fe7fd588832899bbb937138509ee