### PR TITLE
Add 3D cube demo

### DIFF
--- a/src/animation/three.js/cube.tsx
+++ b/src/animation/three.js/cube.tsx
@@ -1,0 +1,60 @@
+import React, { useRef, useEffect } from 'react';
+import * as THREE from 'three';
+
+const Cube: React.FC = () => {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+  const animationRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    if (!canvasRef.current) return;
+
+    const scene = new THREE.Scene();
+    const camera = new THREE.PerspectiveCamera(
+      75,
+      window.innerWidth / window.innerHeight,
+      0.1,
+      1000
+    );
+    const renderer = new THREE.WebGLRenderer({ canvas: canvasRef.current, antialias: true, alpha: true });
+    renderer.setSize(window.innerWidth, window.innerHeight);
+    renderer.setPixelRatio(Math.min(window.devicePixelRatio, 2));
+
+    const geometry = new THREE.BoxGeometry();
+    const material = new THREE.MeshStandardMaterial({ color: 0xff0051 });
+    const cube = new THREE.Mesh(geometry, material);
+    scene.add(cube);
+
+    const light = new THREE.DirectionalLight(0xffffff, 1);
+    light.position.set(3, 3, 3);
+    scene.add(light);
+
+    camera.position.z = 3;
+
+    const animate = () => {
+      animationRef.current = requestAnimationFrame(animate);
+      cube.rotation.x += 0.01;
+      cube.rotation.y += 0.01;
+      renderer.render(scene, camera);
+    };
+
+    animate();
+
+    const handleResize = () => {
+      camera.aspect = window.innerWidth / window.innerHeight;
+      camera.updateProjectionMatrix();
+      renderer.setSize(window.innerWidth, window.innerHeight);
+    };
+
+    window.addEventListener('resize', handleResize);
+
+    return () => {
+      if (animationRef.current) cancelAnimationFrame(animationRef.current);
+      renderer.dispose();
+      window.removeEventListener('resize', handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="w-full h-full" />;
+};
+
+export default Cube;

--- a/src/constants/urls/urls.ts
+++ b/src/constants/urls/urls.ts
@@ -4,3 +4,4 @@ export const p2e = '/p2e';
 export const profile = '/profile';
 export const adminDashboard = '/dashboard';
 export const stats = '/stats';
+export const cube = '/cube';

--- a/src/pages/Layout.tsx
+++ b/src/pages/Layout.tsx
@@ -10,8 +10,9 @@ import { getAccount } from "@wagmi/core";
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { CustomConnectButton } from "@/components/CustomConnectButton";
-import { home, finance, p2e, profile, stats } from "@/constants/urls/urls";
+import { home, finance, p2e, profile, stats, cube } from "@/constants/urls/urls";
 import { FaChartBar } from "react-icons/fa6";
+import { FaCube } from "react-icons/fa";
 import ZumjiLogo from "@/components/logo/Logo";
 import useGetIsOnboarded from "@/hooks/use-get-is-onboarded/useGetIsOnboarded";
 import { useConnectState } from "@/hooks/use-connect/useConnect";
@@ -29,6 +30,7 @@ const Layout = ({ subNavBarTitle, children }: { subNavBarTitle?: string, childre
     { label: "Finance", icon: SiCoinmarketcap, href: finance },
     { label: "P2E", icon: RiBillLine, href: p2e },
     { label: "Stats", icon: FaChartBar, href: stats },
+    { label: "Cube", icon: FaCube, href: cube },
     { label: "Profile", icon: RxAvatar, href: profile },
   ];
 

--- a/src/pages/cube/index.tsx
+++ b/src/pages/cube/index.tsx
@@ -1,0 +1,15 @@
+import React from 'react';
+import Layout from '../Layout';
+import Cube from '@/animation/three.js/cube';
+
+const CubePage: React.FC = () => {
+  return (
+    <Layout subNavBarTitle="Zumji >> Cube">
+      <div className="h-full">
+        <Cube />
+      </div>
+    </Layout>
+  );
+};
+
+export default CubePage;


### PR DESCRIPTION
## Summary
- introduce a simple Three.js cube animation
- expose new `/cube` page via URL constant
- add Cube item to the navigation bar

## Testing
- `npm run lint`
- `npm run build`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6872760793248328be8e18759107013a