### PR TITLE
Add cube tap game with floating ads

### DIFF
--- a/src/animation/three.js/cube.tsx
+++ b/src/animation/three.js/cube.tsx
@@ -1,7 +1,11 @@
 import React, { useRef, useEffect } from 'react';
 import * as THREE from 'three';
 
-const Cube: React.FC = () => {
+interface CubeProps {
+  onCubeClick?: () => void;
+}
+
+const Cube: React.FC<CubeProps> = ({ onCubeClick }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
   const animationRef = useRef<number | null>(null);
 
@@ -24,6 +28,9 @@ const Cube: React.FC = () => {
     const cube = new THREE.Mesh(geometry, material);
     scene.add(cube);
 
+    const raycaster = new THREE.Raycaster();
+    const mouse = new THREE.Vector2();
+
     const light = new THREE.DirectionalLight(0xffffff, 1);
     light.position.set(3, 3, 3);
     scene.add(light);
@@ -39,6 +46,20 @@ const Cube: React.FC = () => {
 
     animate();
 
+    const handleClick = (event: MouseEvent) => {
+      if (!canvasRef.current) return;
+      const rect = canvasRef.current.getBoundingClientRect();
+      mouse.x = ((event.clientX - rect.left) / rect.width) * 2 - 1;
+      mouse.y = -((event.clientY - rect.top) / rect.height) * 2 + 1;
+      raycaster.setFromCamera(mouse, camera);
+      const intersects = raycaster.intersectObject(cube);
+      if (intersects.length > 0) {
+        onCubeClick?.();
+      }
+    };
+
+    canvasRef.current.addEventListener('click', handleClick);
+
     const handleResize = () => {
       camera.aspect = window.innerWidth / window.innerHeight;
       camera.updateProjectionMatrix();
@@ -51,6 +72,7 @@ const Cube: React.FC = () => {
       if (animationRef.current) cancelAnimationFrame(animationRef.current);
       renderer.dispose();
       window.removeEventListener('resize', handleResize);
+      canvasRef.current?.removeEventListener('click', handleClick);
     };
   }, []);
 

--- a/src/components/ads/FloatingAds.tsx
+++ b/src/components/ads/FloatingAds.tsx
@@ -1,0 +1,31 @@
+import React from 'react';
+
+interface Ad {
+  src: string;
+  alt: string;
+  delay: number;
+}
+
+const ads: Ad[] = [
+  { src: '/tap.jpeg', alt: 'Ad 1', delay: 0 },
+  { src: '/celo.png', alt: 'Ad 2', delay: 2 },
+  { src: '/images/logo/zumji_logo.jpeg', alt: 'Ad 3', delay: 4 },
+];
+
+const FloatingAds: React.FC = () => {
+  return (
+    <div className="pointer-events-none fixed inset-0 z-30 overflow-hidden">
+      {ads.map((ad, idx) => (
+        <img
+          key={idx}
+          src={ad.src}
+          alt={ad.alt}
+          style={{ animationDelay: `${ad.delay}s` }}
+          className="absolute w-20 h-20 opacity-80 animate-ad-float"
+        />
+      ))}
+    </div>
+  );
+};
+
+export default FloatingAds;

--- a/src/pages/cube/index.tsx
+++ b/src/pages/cube/index.tsx
@@ -1,12 +1,21 @@
-import React from 'react';
+import React, { useState } from 'react';
 import Layout from '../Layout';
 import Cube from '@/animation/three.js/cube';
+import FloatingAds from '@/components/ads/FloatingAds';
 
 const CubePage: React.FC = () => {
+  const [score, setScore] = useState(0);
+
+  const handleCubeClick = () => setScore((s) => s + 1);
+
   return (
     <Layout subNavBarTitle="Zumji >> Cube">
-      <div className="h-full">
-        <Cube />
+      <div className="relative h-full w-full">
+        <div className="absolute top-4 left-4 z-20 text-white text-lg font-bold bg-black/60 px-3 py-1 rounded-md">
+          Score: {score}
+        </div>
+        <Cube onCubeClick={handleCubeClick} />
+        <FloatingAds />
       </div>
     </Layout>
   );

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -21,11 +21,19 @@ module.exports = konstaConfig({
       },
       animation: {
         'star-move': 'starMove 30s linear infinite',
+        'ad-float': 'adFloat 15s linear infinite',
       },
       keyframes: {
         starMove: {
           '0%': { transform: 'translateX(0)' },
           '100%': { transform: 'translateX(-2000px)' },
+        },
+        adFloat: {
+          '0%': { transform: 'translate(-10%, -10%) rotate(0deg)' },
+          '25%': { transform: 'translate(110%, -10%) rotate(90deg)' },
+          '50%': { transform: 'translate(110%, 110%) rotate(180deg)' },
+          '75%': { transform: 'translate(-10%, 110%) rotate(270deg)' },
+          '100%': { transform: 'translate(-10%, -10%) rotate(360deg)' },
         },
       },
     },


### PR DESCRIPTION
## Summary
- add interactive three.js cube that increments score on click
- display score on cube page
- implement floating ads that don't block interactions
- add `ad-float` animation in Tailwind

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_68739c53580c83289f2e94b00097a1a0